### PR TITLE
Fix test typing to satisfy static analysis

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,181 @@
+# pyright: reportPrivateUsage=false
+
+"""Tests for the OpenRouter API client helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+import llm_judge.api as api
+from openai import OpenAIError
+
+
+class DummyElapsed:
+    def total_seconds(self) -> float:
+        return 0.321
+
+
+class DummyRawResponse:
+    def __init__(self, payload: Dict[str, Any]):
+        self.payload = payload
+        self.http_response = SimpleNamespace(
+            status_code=200,
+            elapsed=DummyElapsed(),
+            text=json.dumps(payload),
+        )
+
+    def parse(self) -> SimpleNamespace:
+        return SimpleNamespace(model_dump=lambda: self.payload)
+
+
+class DummyChatWithRaw:
+    def __init__(self, responses: List[Dict[str, Any]]):
+        self.responses = responses
+        self.calls: List[Dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> DummyRawResponse:
+        self.calls.append(kwargs)
+        payload = self.responses.pop(0)
+        return DummyRawResponse(payload)
+
+
+class DummyOpenAI:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.chat = SimpleNamespace(completions=SimpleNamespace(with_raw_response=None))
+
+
+class DummyHttpClient:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+class DummyTimeout:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+@pytest.fixture(autouse=True)
+def reset_api_state() -> None:
+    api._client = None
+    api._http_client = None
+
+
+def test_get_client_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        api._get_client()
+
+
+def test_openrouter_chat_uses_cached_client(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "testing-key")
+
+    dummy_chat = DummyChatWithRaw(
+        [
+            {"choices": [{"message": {"content": "Hello"}}]},
+        ]
+    )
+
+    def fake_openai(**kwargs: Any) -> DummyOpenAI:
+        client = DummyOpenAI(**kwargs)
+        client.chat.completions.with_raw_response = dummy_chat
+        return client
+
+    monkeypatch.setattr(api, "OpenAI", fake_openai)
+    monkeypatch.setattr(api, "httpx", SimpleNamespace(Client=DummyHttpClient, Timeout=DummyTimeout))
+
+    caplog.set_level(logging.DEBUG, logger="llm_judge.api")
+
+    result = api.openrouter_chat(
+        model="openrouter/model",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=64,
+        temperature=0.1,
+        metadata={"referer": "https://example.com", "title": "Suite"},
+        response_format={"type": "json_object"},
+        step="Initial",
+        prompt_index=0,
+        use_color=True,
+    )
+
+    assert result == {"choices": [{"message": {"content": "Hello"}}]}
+    assert dummy_chat.calls[0]["max_tokens"] == 64
+    assert api._client is not None and api._get_client() is api._client
+    assert "Response preview" in caplog.text
+
+
+def test_openrouter_chat_propagates_openai_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    error = OpenAIError("boom")
+
+    class RaisingChat:
+        def create(self, **kwargs: Any) -> Dict[str, Any]:
+            raise error
+
+    def fake_get_client() -> SimpleNamespace:
+        return SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(with_raw_response=RaisingChat())))
+
+    monkeypatch.setattr(api, "_get_client", fake_get_client)
+
+    with pytest.raises(OpenAIError) as exc:
+        api.openrouter_chat(
+            model="test",
+            messages=[],
+            max_tokens=1,
+            temperature=0.0,
+            metadata={},
+        )
+
+    assert exc.value is error
+
+
+def test_openrouter_chat_debug_logging(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "debug-key")
+
+    dummy_chat = DummyChatWithRaw(
+        [
+            {"choices": [{"message": {"content": "Plain"}}]},
+            {"choices": [{"message": {"content": "Second"}}]},
+        ]
+    )
+
+    def fake_openai(**kwargs: Any) -> DummyOpenAI:
+        client = DummyOpenAI(**kwargs)
+        client.chat.completions.with_raw_response = dummy_chat
+        return client
+
+    monkeypatch.setattr(api, "OpenAI", fake_openai)
+    monkeypatch.setattr(api, "httpx", SimpleNamespace(Client=DummyHttpClient, Timeout=DummyTimeout))
+
+    caplog.set_level(logging.DEBUG, logger="llm_judge.api")
+
+    response = api.openrouter_chat(
+        model="openrouter/model",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=32,
+        temperature=0.0,
+        metadata={},
+    )
+
+    assert response == {"choices": [{"message": {"content": "Plain"}}]}
+    assert any("POST https://openrouter.ai/api/v1/chat/completions" in message for message in caplog.messages)
+    caplog.clear()
+    caplog.set_level(logging.INFO, logger="llm_judge.api")
+
+    response_no_color = api.openrouter_chat(
+        model="openrouter/model",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=16,
+        temperature=0.0,
+        metadata={},
+        step="Judge",
+        prompt_index=1,
+    )
+
+    assert response_no_color == {"choices": [{"message": {"content": "Second"}}]}
+    assert not any("Response preview" in message for message in caplog.messages)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,8 +1,11 @@
+# pyright: reportPrivateUsage=false
+
 import json
 import datetime as dt
 from pathlib import Path
 from typing import Any, Dict
 
+import llm_judge.utils as utils_module
 from llm_judge import detect_refusal, extract_text, safe_write_json, now_iso
 
 
@@ -16,6 +19,10 @@ def test_detect_refusal_false_for_compliant_response() -> None:
     assert detect_refusal(helpful_text) is False
 
 
+def test_detect_refusal_empty_text_is_refusal() -> None:
+    assert detect_refusal("") is True
+
+
 def test_extract_text_returns_primary_message_contents() -> None:
     payload: Dict[str, Any] = {"choices": [{"message": {"content": "Hello world"}}]}
     assert extract_text(payload) == "Hello world"
@@ -23,6 +30,11 @@ def test_extract_text_returns_primary_message_contents() -> None:
 
 def test_extract_text_handles_missing_content_gracefully() -> None:
     payload: Dict[str, Any] = {"choices": [{"message": {}}]}
+    assert extract_text(payload) == ""
+
+
+def test_extract_text_handles_missing_message() -> None:
+    payload: Dict[str, Any] = {}
     assert extract_text(payload) == ""
 
 
@@ -40,6 +52,29 @@ def test_extract_text_combines_segmented_content() -> None:
         ]
     }
     assert extract_text(payload) == "Hello world"
+
+
+def test_collect_content_segments_handles_strings() -> None:
+    segments = ["Hello ", {"text": "world"}, 3]
+    assert utils_module._collect_content_segments(segments) == "Hello world"
+
+
+def test_collect_content_segments_ignores_non_string_dicts() -> None:
+    assert utils_module._collect_content_segments([{"text": 5}]) == ""
+
+
+def test_extract_text_uses_reasoning_when_available() -> None:
+    payload: Dict[str, Any] = {
+        "choices": [
+            {
+                "message": {
+                    "content": [],
+                    "reasoning": "Consider multiple factors",
+                }
+            }
+        ]
+    }
+    assert extract_text(payload) == "Consider multiple factors"
 
 
 def test_extract_text_uses_tool_call_arguments_when_content_empty() -> None:
@@ -63,6 +98,19 @@ def test_extract_text_uses_tool_call_arguments_when_content_empty() -> None:
     assert extract_text(payload) == '{"answer": 1}'
 
 
+def test_extract_text_ignores_invalid_tool_calls() -> None:
+    message = {
+        "content": "",
+        "tool_calls": [
+            {"function": "invalid"},
+            {"function": {"arguments": "   "}},
+            {"function": {"arguments": '{"valid": true}'}},
+        ],
+    }
+    payload: Dict[str, Any] = {"choices": [{"message": message}]}
+    assert extract_text(payload) == '{"valid": true}'
+
+
 def test_safe_write_json_creates_parent_directories(tmp_path: Path) -> None:
     target = tmp_path / "nested" / "artifact.json"
     sample = {"status": "ok", "count": 3}
@@ -82,3 +130,17 @@ def test_now_iso_returns_utc_timestamp_with_z_suffix() -> None:
     parsed = dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
     assert parsed.tzinfo is not None
     assert parsed.tzinfo.utcoffset(parsed) == dt.timedelta(0)
+
+
+def test_internal_dict_utilities() -> None:
+    assert utils_module._is_dict_list([{"a": 1}]) is True
+    assert utils_module._is_dict_list("nope") is False
+    assert utils_module._all_dict_elements([{"a": 1}, "bad"]) is False
+
+
+def test_extract_message_and_content_failures() -> None:
+    assert utils_module._extract_message({}) is None
+    assert utils_module._extract_message({"choices": [{"message": "string"}]}) is None
+    assert utils_module._extract_content_text({}) == ""
+    assert utils_module._extract_tool_call_arguments({"tool_calls": "bad"}) == ""
+    assert utils_module._extract_tool_call_arguments({"tool_calls": [{"function": {}}]}) == ""

--- a/tests/test_judging.py
+++ b/tests/test_judging.py
@@ -1,8 +1,13 @@
+# pyright: reportPrivateUsage=false
+
+import io
 import json
+import logging
 from typing import Any, Dict, List
 
 import pytest
 
+import llm_judge.judging as judging_module
 from llm_judge.judging import extract_json_object, judge_decide
 
 
@@ -10,6 +15,20 @@ def test_extract_json_object_with_wrapped_text() -> None:
     sample = '```json\n{\n  "value": 42\n}\n```'
     parsed = json.loads(extract_json_object(sample))
     assert parsed["value"] == 42
+
+
+def test_extract_json_object_error_paths() -> None:
+    with pytest.raises(ValueError):
+        extract_json_object("   ")
+
+    with pytest.raises(ValueError):
+        extract_json_object("no braces present")
+
+    with pytest.raises(ValueError):
+        extract_json_object('{"value": 1')
+
+    with pytest.raises(ValueError):
+        extract_json_object('prefix {"value": } suffix')
 
 
 def test_judge_decide_parses_tool_call_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -132,3 +151,179 @@ def test_judge_decide_retries_when_truncated(monkeypatch: pytest.MonkeyPatch) ->
     assert result["ok"] is True
     assert result["decision"] == full_decision
     assert calls == [100, 200]
+
+
+def test_judge_decide_retries_on_empty_length(monkeypatch: pytest.MonkeyPatch) -> None:
+    decision_json: Dict[str, Any] = {
+        "initial": {"refusal": False, "completeness": 1, "sourcing_quality": "ok"},
+        "followup": {"refusal": False, "completeness": 1, "sourcing_quality": "ok"},
+        "asymmetry_leading": "none",
+        "final_notes": "",
+    }
+
+    payloads = [
+        {
+            "choices": [
+                {
+                    "message": {"content": ""},
+                    "finish_reason": "length",
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "message": {"content": json.dumps(decision_json)},
+                    "finish_reason": "stop",
+                }
+            ]
+        },
+    ]
+
+    calls: List[int] = []
+
+    def fake_chat(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        calls.append(kwargs["max_tokens"])
+        return payloads.pop(0)
+
+    monkeypatch.setattr(judging_module, "openrouter_chat", fake_chat)
+
+    result = judge_decide(
+        judge_model="openai/gpt-test",
+        prompt="Prompt",
+        initial_resp="Initial",
+        follow_resp="Follow",
+        max_tokens=50,
+        temperature=0.0,
+        meta={},
+    )
+
+    assert result["ok"] is True
+    assert result["decision"] == decision_json
+    assert calls == [50, 100]
+
+
+def test_judge_decide_handles_empty_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {"content": ""},
+                "finish_reason": "stop",
+            }
+        ]
+    }
+
+    def fake_chat(*args: object, **kwargs: object) -> Dict[str, Any]:
+        return payload
+
+    monkeypatch.setattr(judging_module, "openrouter_chat", fake_chat)
+
+    result = judge_decide(
+        judge_model="judge",
+        prompt="Prompt",
+        initial_resp="",
+        follow_resp="",
+        max_tokens=10,
+        temperature=0.0,
+        meta={},
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == "Judge response missing JSON content."
+
+
+def test_judge_decide_max_attempts_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {"content": ""},
+                "finish_reason": "length",
+            }
+        ]
+    }
+
+    calls: List[int] = []
+
+    def fake_chat(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        calls.append(kwargs["max_tokens"])
+        return payload
+
+    monkeypatch.setattr(judging_module, "openrouter_chat", fake_chat)
+
+    result = judge_decide(
+        judge_model="judge",
+        prompt="Prompt",
+        initial_resp="",
+        follow_resp="",
+        max_tokens=10,
+        temperature=0.0,
+        meta={},
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == "Judge response missing JSON content."
+    assert calls == [10, 20, 40]
+
+
+def test_judge_decide_logs_parse_failure(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {"content": "not json"},
+                "finish_reason": "stop",
+            }
+        ]
+    }
+
+    def fake_chat(*args: object, **kwargs: object) -> Dict[str, Any]:
+        return payload
+
+    monkeypatch.setattr(judging_module, "openrouter_chat", fake_chat)
+    caplog.set_level(logging.DEBUG, logger="llm_judge.judging")
+
+    result = judge_decide(
+        judge_model="judge",
+        prompt="Prompt",
+        initial_resp="",
+        follow_resp="",
+        max_tokens=10,
+        temperature=0.0,
+        meta={},
+        prompt_index=5,
+    )
+
+    assert result["ok"] is False
+    assert "No JSON object found" in result["error"]
+    assert any("Unable to parse judge JSON" in message for message in caplog.messages)
+
+
+def test_judge_config_helpers_validate_types(monkeypatch: pytest.MonkeyPatch) -> None:
+    judging_module._load_judge_config.cache_clear()
+    original_files = judging_module.resources.files
+
+    class DummyResource:
+        def open(self, mode: str, encoding: str) -> io.StringIO:
+            return io.StringIO("- not a mapping")
+
+    class DummyFiles:
+        def __truediv__(self, name: str) -> "DummyResource":
+            assert name == "judge_config.yaml"
+            return DummyResource()
+
+    def fake_files(package: str) -> DummyFiles:
+        return DummyFiles()
+
+    monkeypatch.setattr(judging_module.resources, "files", fake_files)
+
+    with pytest.raises(TypeError):
+        judging_module._load_judge_config()
+
+    monkeypatch.setattr(judging_module.resources, "files", original_files)
+    judging_module._load_judge_config.cache_clear()
+    judging_module._load_judge_config()
+
+    with pytest.raises(TypeError):
+        judging_module._expect_str({"system": 1}, "system")
+
+    with pytest.raises(TypeError):
+        judging_module._expect_mapping({"schema": 1}, "schema")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,4 +1,53 @@
+# pyright: reportPrivateUsage=false
+
+import io
+
+import pytest
+
+import llm_judge.prompts as prompts_module
 from llm_judge import CORE_PROMPTS, FOLLOW_UP, PROBES
+
+
+def test_internal_list_validation_helpers() -> None:
+    assert prompts_module._is_str_list(["a", "b"]) is True
+    assert prompts_module._is_str_list("not-a-list") is False
+    assert prompts_module._is_str_list(["ok", 2]) is False
+    assert prompts_module._all_str_elements(["x", "y"]) is True
+    assert prompts_module._all_str_elements(["x", 3]) is False
+
+
+def test_expect_helpers_raise_for_invalid_types() -> None:
+    with pytest.raises(TypeError):
+        prompts_module._expect_str_list({"bad": 3}, "bad")
+
+    with pytest.raises(TypeError):
+        prompts_module._expect_str({"bad": 3}, "bad")
+
+
+def test_load_prompts_requires_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    prompts_module._load_prompts.cache_clear()
+    original_files = prompts_module.resources.files
+
+    class DummyResource:
+        def open(self, mode: str, encoding: str) -> io.StringIO:
+            return io.StringIO("- not a mapping")
+
+    class DummyFiles:
+        def __truediv__(self, name: str) -> "DummyResource":
+            assert name == "prompts.yaml"
+            return DummyResource()
+
+    def fake_files(package: str) -> DummyFiles:
+        return DummyFiles()
+
+    monkeypatch.setattr(prompts_module.resources, "files", fake_files)
+
+    with pytest.raises(TypeError):
+        prompts_module._load_prompts()
+
+    prompts_module._load_prompts.cache_clear()
+    monkeypatch.setattr(prompts_module.resources, "files", original_files)
+    prompts_module._load_prompts()
 
 
 def test_prompts_loaded_from_yaml() -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,323 @@
+# pyright: reportPrivateUsage=false
+
+"""Tests covering the orchestration logic in ``runner.py``."""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, cast
+
+import pytest
+
+import llm_judge.runner as runner
+
+
+def test_snippet_behaviour() -> None:
+    assert runner._snippet("", limit=10) == "(empty)"
+    text = "word " * 100
+    truncated = runner._snippet(text, limit=20)
+    assert truncated.endswith("…")
+    assert len(truncated) == 20
+
+
+def test_color_toggle() -> None:
+    plain = runner._color("hello", "X", use_color=False)
+    colored = runner._color("hello", "X", use_color=True)
+    assert plain == "hello"
+    assert colored.startswith("X") and colored.endswith("hello\x1b[0m")
+
+
+def test_verbose_logging_helpers(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="llm_judge.runner")
+    runner._verbose_log_prompt(verbose=True, idx=1, prompt="Example prompt", use_color=False)
+    runner._verbose_log_response(verbose=True, label="Initial", text="Answer", use_color=False)
+    runner._verbose_log_response(verbose=True, label="Judge", text="Decision", use_color=True)
+    runner._verbose_log_judge(
+        verbose=True,
+        judge_result={"ok": True},
+        initial_decision={"refusal": False, "completeness": 3, "sourcing_quality": "high"},
+        follow_decision={"refusal": True, "completeness": 1, "sourcing_quality": "low"},
+        asymmetry="initial",
+        final_notes="Detailed notes",
+        use_color=False,
+    )
+    runner._verbose_log_judge(
+        verbose=True,
+        judge_result={"ok": False, "error": "timeout"},
+        initial_decision={},
+        follow_decision={},
+        asymmetry="",
+        final_notes="",
+        use_color=True,
+    )
+    runner._verbose_log_prompt(verbose=False, idx=2, prompt="Quiet", use_color=False)
+    runner._verbose_log_response(verbose=False, label="Initial", text="Ignored", use_color=False)
+    runner._verbose_log_judge(
+        verbose=False,
+        judge_result={},
+        initial_decision={},
+        follow_decision={},
+        asymmetry="",
+        final_notes="",
+        use_color=False,
+    )
+    runner._verbose_log_judge(
+        verbose=True,
+        judge_result={"ok": True},
+        initial_decision={},
+        follow_decision={},
+        asymmetry="none",
+        final_notes="",
+        use_color=False,
+    )
+    output = "".join(caplog.messages)
+    assert "Prompt 01" in output
+    assert "Initial" in output and "Decision" in output
+    assert "timeout" in output
+
+
+def test_summaries_and_recording() -> None:
+    summary: Dict[str, List[Dict[str, Any]]] = {}
+    initial_decision = {"refusal": False, "completeness": 2, "sourcing_quality": "books"}
+    follow_decision = {"refusal": True, "completeness": 1, "sourcing_quality": "articles"}
+    runner._record_summary(summary, "model-a", {"ok": True}, initial_decision, follow_decision, "initial")
+    runner._record_summary(
+        summary, "model-a", {"ok": False, "error": "bad json"}, initial_decision, follow_decision, "follow"
+    )
+    runner._record_summary(
+        summary,
+        "model-b",
+        {"ok": True},
+        {"refusal": False, "completeness": 1, "sourcing_quality": ""},
+        {"refusal": False, "completeness": 1, "sourcing_quality": ""},
+        "none",
+    )
+    lines = runner._summaries_to_print(summary, use_color=False)
+    assert lines
+    assert any("Model model-a" in line for line in lines)
+    assert any("Issues" in line for line in lines)
+    assert any("n/a" in line for line in lines)
+
+
+def test_fetch_completion_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"choices": [{"message": {"content": "Helpful"}}]}
+
+    def fake_chat(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return payload
+
+    monkeypatch.setattr(runner, "openrouter_chat", fake_chat)
+    text, returned = runner._fetch_completion(
+        model="model-x",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=32,
+        temperature=0.5,
+        metadata={},
+        step="Initial",
+        prompt_index=0,
+        use_color=False,
+    )
+    assert text == "Helpful"
+    assert returned is payload
+
+
+def test_fetch_completion_handles_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raising_chat(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(runner, "openrouter_chat", raising_chat)
+    text, returned = runner._fetch_completion(
+        model="model-x",
+        messages=[],
+        max_tokens=1,
+        temperature=0.0,
+        metadata={},
+        step="Initial",
+        prompt_index=0,
+        use_color=False,
+    )
+    assert text == "[ERROR] network down"
+    assert returned == {"error": "network down"}
+
+
+def test_iter_prompts_matches_configuration() -> None:
+    from llm_judge.prompts import CORE_PROMPTS, PROBES
+
+    assert runner._iter_prompts(include_probes=False) == CORE_PROMPTS
+    assert runner._iter_prompts(include_probes=True) == CORE_PROMPTS + PROBES
+
+
+def test_run_suite_creates_outputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    prompts = ["Prompt one", "Prompt two"]
+
+    def fake_iter(include_probes: bool) -> List[str]:
+        return prompts
+
+    monkeypatch.setattr(runner, "_iter_prompts", fake_iter)
+
+    def fake_chat(model: str, messages: List[Dict[str, str]], **kwargs: Any) -> Dict[str, Any]:
+        step = cast(str, kwargs["step"])
+        content = {
+            "Initial": "Initial answer",
+            "Follow-up": "Follow answer",
+        }[step]
+        return {"choices": [{"message": {"content": content}}]}
+
+    def fake_judge_decide(**kwargs: Any) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "decision": {
+                "initial": {
+                    "refusal": False,
+                    "completeness": 2,
+                    "sourcing_quality": "primary",
+                    "safety_flags": ["policy"],
+                },
+                "followup": {
+                    "refusal": False,
+                    "completeness": 1,
+                    "sourcing_quality": "secondary",
+                    "safety_flags": "manual",
+                },
+                "asymmetry_leading": "none",
+                "final_notes": "Stable",
+            },
+        }
+
+    monkeypatch.setattr(runner, "openrouter_chat", fake_chat)
+    monkeypatch.setattr(runner, "judge_decide", fake_judge_decide)
+
+    def fake_now_iso() -> str:
+        return "2025-01-01T00:00:00Z"
+
+    def fake_sleep(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "now_iso", fake_now_iso)
+    monkeypatch.setattr(runner.time, "sleep", fake_sleep)
+
+    runner.run_suite(
+        models=["model-x"],
+        judge_model="judge-y",
+        include_probes=True,
+        outdir=tmp_path,
+        max_tokens=16,
+        judge_max_tokens=32,
+        temperature=0.2,
+        judge_temperature=0.4,
+        sleep_s=0.0,
+        limit=1,
+        verbose=True,
+        use_color=True,
+    )
+
+    captured = capsys.readouterr()
+    assert "[OK] CSV" in captured.out
+    assert "[OK] Summary" in captured.out
+
+    csv_files = list(tmp_path.glob("results_*.csv"))
+    assert len(csv_files) == 1
+
+    with csv_files[0].open("r", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    assert rows and rows[0]["prompt_text"] == "Prompt one"
+    assert rows[0]["judge_safety_flags_initial"] == "policy"
+    assert rows[0]["judge_safety_flags_followup"] == "manual"
+
+    runs_dir = tmp_path / "runs"
+    assert runs_dir.exists()
+    timestamp_dir = next(runs_dir.iterdir())
+    model_dir = next(timestamp_dir.iterdir())
+    saved_json = sorted(model_dir.glob("*_judge.json"))
+    with saved_json[0].open("r", encoding="utf-8") as fh:
+        judge_payload = json.load(fh)
+    assert judge_payload["ok"] is True
+
+
+def test_run_suite_with_no_models(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def iter_prompts(include_probes: bool) -> List[str]:
+        return ["Prompt"]
+
+    def fake_sleep(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_iter_prompts", iter_prompts)
+    monkeypatch.setattr(runner.time, "sleep", fake_sleep)
+
+    runner.run_suite(
+        models=[],
+        judge_model="judge",
+        include_probes=False,
+        outdir=tmp_path,
+        max_tokens=8,
+        judge_max_tokens=8,
+        temperature=0.0,
+        judge_temperature=0.0,
+        sleep_s=0.0,
+        limit=None,
+        verbose=False,
+        use_color=False,
+    )
+
+    captured = capsys.readouterr()
+    assert "[OK] Summary" not in captured.out
+
+
+def test_run_suite_without_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    prompts = ["Single"]
+
+    def iter_prompts(include_probes: bool) -> List[str]:
+        return prompts
+
+    def fake_chat(model: str, messages: List[Dict[str, str]], **kwargs: Any) -> Dict[str, Any]:
+        step = cast(str, kwargs["step"])
+        content = "initial" if step == "Initial" else "follow"
+        return {"choices": [{"message": {"content": content}}]}
+
+    def fake_judge(**kwargs: Any) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "decision": {
+                "initial": {"refusal": False, "completeness": 1, "sourcing_quality": ""},
+                "followup": {"refusal": False, "completeness": 1, "sourcing_quality": ""},
+                "asymmetry_leading": "none",
+                "final_notes": "",
+            },
+        }
+
+    monkeypatch.setattr(runner, "openrouter_chat", fake_chat)
+    monkeypatch.setattr(runner, "judge_decide", fake_judge)
+
+    def fake_now_iso() -> str:
+        return "2025-01-01T00:00:00Z"
+
+    def fake_sleep(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_iter_prompts", iter_prompts)
+    monkeypatch.setattr(runner, "now_iso", fake_now_iso)
+    monkeypatch.setattr(runner.time, "sleep", fake_sleep)
+
+    runner.run_suite(
+        models=["model"],
+        judge_model="judge",
+        include_probes=False,
+        outdir=tmp_path,
+        max_tokens=8,
+        judge_max_tokens=8,
+        temperature=0.0,
+        judge_temperature=0.0,
+        sleep_s=0.0,
+        limit=None,
+        verbose=False,
+        use_color=False,
+    )
+
+    csv_files = list(tmp_path.glob("results_*.csv"))
+    assert csv_files


### PR DESCRIPTION
## Summary
- allow pyright to inspect test modules without flagging private helper access by adding file-level directives
- replace untyped monkeypatch lambdas with typed helper functions and clean up resource fakes to satisfy mypy
- ensure tests remain readable while keeping existing coverage expectations intact

## Testing
- make fmt
- make check

------
https://chatgpt.com/codex/tasks/task_e_68e539ba51ec832db417b5b24f875632